### PR TITLE
Update twitpic.sh

### DIFF
--- a/twitpic.sh
+++ b/twitpic.sh
@@ -87,6 +87,7 @@ for ID in $ALL_IDS; do
 	fi
 	FULL_FILE=$PREFIX-$ID-full$EXT
 	if [ ! -f "images/$FULL_FILE" ]; then
+	  FULL_URL=`echo $FULL_URL | sed 's/https/http/g'`
 	  wget "$FULL_URL" -O "images/$FULL_FILE"
 	fi
   fi


### PR DESCRIPTION
cloudfront.net responds to either http or https requests.  For those versions of wget that do not support OpenSSL (BusyBox, etc.) I change the image download URL from https to http.

Tested using CM11 : 11-20140830-NIGHTLY-m7 (Android 4.4.4) | busybox v1.22.1 | Script Manager 2.9.6
